### PR TITLE
Added nightly toolchain file

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly-2022-02-01"


### PR DESCRIPTION
I noticed that no toolchain file exists, probably because you're using a directory-specific toolchain override locally. This should help others looking to build the project! `2022-02-01` was the most recent toolchain I could find that could build the project.